### PR TITLE
convert existing use of metrics ping to custom pings, add request-stats custom ping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+OUTPUT_DIR := build
+
+.PHONY: lint translate
+
+lint: ## ling the yaml files
+	@echo "Glinting..."
+	@glean_parser glinter telemetry/glean/metrics.yaml telemetry/glean/pings.yaml
+
+translate: ## generate the go server code from the yaml files
+	@echo "Generating go server package..."
+	@glean_parser translate -o ${OUTPUT_DIR} -f go_server telemetry/glean/metrics.yaml telemetry/glean/pings.yaml

--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -12,6 +12,7 @@ ad:
       null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
     notification_emails:
       - gleonard@mozilla.com
@@ -28,6 +29,7 @@ ad:
       Advertiser associated with the ad.  Should not be null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
     notification_emails:
       - gleonard@mozilla.com
@@ -44,23 +46,7 @@ ad:
       Advertiser/partner provided identifier for a specific ad.  May be null.
     lifetime: application
     send_in_pings:
-      - interaction
-    notification_emails:
-      - gleonard@mozilla.com
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/AE-355
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
-    expires: never
-
-  flight_id:
-    type: string
-    description: >
-      Flight Id defined in Kevel metadata.  Will be null if interaction is
-      not from a Kevel supplied ad.
-    lifetime: application
-    send_in_pings:
+      - events
       - interaction
     notification_emails:
       - gleonard@mozilla.com
@@ -77,6 +63,7 @@ ad:
       The external service providing the ad.  Should not be null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
     notification_emails:
       - gleonard@mozilla.com
@@ -94,6 +81,7 @@ ad:
       carousel, video).  Should not be null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
     notification_emails:
       - gleonard@mozilla.com
@@ -111,6 +99,7 @@ ad:
       format can map to one product.  Should not be null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
     notification_emails:
       - gleonard@mozilla.com
@@ -146,8 +135,26 @@ ad:
       be null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
       - request-stats
+    notification_emails:
+      - gleonard@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-355
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
+    expires: never
+
+  flight_id:
+    type: string
+    description: >
+      Flight Id defined in Kevel metadata.  Will be null if interaction is
+      not from a Kevel supplied ad.
+    lifetime: application
+    send_in_pings:
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -165,6 +172,7 @@ ad_client:
       client.  Should not be null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
     notification_emails:
       - gleonard@mozilla.com
@@ -182,6 +190,7 @@ ad_client:
       ad (e.g. newtab). Should not be null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
       - request-stats
     notification_emails:
@@ -200,6 +209,7 @@ ad_client:
       (e.g. "1", "2", "top", "left-side").  May be null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
     notification_emails:
       - gleonard@mozilla.com
@@ -217,6 +227,7 @@ ad_client:
       Should not be null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
       - request-stats
     notification_emails:
@@ -234,6 +245,7 @@ ad_client:
       OS of the device displaying the ad.  May be null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
     notification_emails:
       - gleonard@mozilla.com
@@ -244,6 +256,37 @@ ad_client:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
     expires: never
 
+interaction:
+  kevel:
+    type: event
+    description: >
+      Captures specific Kevel fields.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-355
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
+    notification_emails:
+      - gleonard@mozilla.com
+    expires: never
+    extra_keys:
+      flight_id:
+        description: >
+          Flight Id defined in Kevel metadata.
+        type: string
+  amp:
+    type: event
+    description: >
+      Captures specific AMP fields.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-355
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
+    notification_emails:
+      - gleonard@mozilla.com
+    expires: never
+
 technical_operations:
   user_agent:
     type: string
@@ -252,6 +295,7 @@ technical_operations:
       analytics value.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
     notification_emails:
       - gleonard@mozilla.com
@@ -271,6 +315,7 @@ technical_operations:
       differ by milliseconds. Should not be null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
       - request-stats
     notification_emails:
@@ -291,6 +336,7 @@ technical_operations:
       two timestamps will differ by milliseconds. Should not be null.
     lifetime: application
     send_in_pings:
+      - events
       - interaction
     notification_emails:
       - gleonard@mozilla.com

--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -7,11 +7,13 @@ $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 ad:
   interaction:
     type: string
-    description: |
-      The type of ad interaction (e.g. impression, click, ...).  Should not be null.
+    description: >
+      The type of ad interaction (e.g. impression, click, ...).  Should not be
+      null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -23,11 +25,12 @@ ad:
 
   advertiser:
     type: string
-    description: |
+    description: >
       Advertiser associated with the ad.  Should not be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -39,11 +42,28 @@ ad:
 
   id:
     type: string
-    description: |
+    description: >
       Advertiser/partner provided identifier for a specific ad.  May be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
+    notification_emails:
+      - gleonard@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-355
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
+    expires: never
+
+  flight_id:
+    type: string
+    description: >
+      Flight Id defined in Kevel metadata.  May be null.
+    lifetime: application
+    send_in_pings:
+      - kevel-interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -55,11 +75,12 @@ ad:
 
   provider:
     type: string
-    description: |
+    description: >
       The external service providing the ad.  Should not be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -71,11 +92,13 @@ ad:
 
   product:
     type: string
-    description: |
-      The category of ad requested by the client. (e.g. tiles, native, banner, carousel, video).  Should not be null.
+    description: >
+      The category of ad requested by the client. (e.g. tiles, native, banner,
+      carousel, video).  Should not be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -87,11 +110,13 @@ ad:
 
   format:
     type: string
-    description: |
-      Format of the ad which satisfied the requested placement.  More than one format can map to one product.  Should not be null.
+    description: >
+      Format of the ad which satisfied the requested placement.  More than one
+      format can map to one product.  Should not be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -103,11 +128,14 @@ ad:
 
   country_code:
     type: string
-    description: |
-      Country code associated with the client when the ad was requested.  Should not be null.
+    description: >
+      Country code associated with the client when the ad was requested.
+      Should not be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
+      - request-stats
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -119,11 +147,14 @@ ad:
 
   region_code:
     type: string
-    description: |
-      Region code associated with the client when the ad was requested.  May be null.
+    description: >
+      Region code associated with the client when the ad was requested.  May
+      be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
+      - request-stats
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -136,10 +167,13 @@ ad:
 ad_client:
   context_id:
     type: string
-    description: A unique identifier representing an application user; provided by the client.  Should not be null.
+    description: >
+      A unique identifier representing an application user; provided by the
+      client.  Should not be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -151,27 +185,14 @@ ad_client:
 
   placement:
     type: string
-    description: |
-      Value identifying the surface; provided by the client when requesting an ad (e.g. newtab). Should not be null.
+    description: >
+      Value identifying the surface; provided by the client when requesting an
+      ad (e.g. newtab). Should not be null.
     lifetime: application
     send_in_pings:
-      - events
-    notification_emails:
-      - gleonard@mozilla.com
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/AE-355
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
-    expires: never
-
-  placement_id:
-    type: string
-    description: |
-      Unique identifer representing an instance of a placement (e.g. newtab_visit_id).  May be null.
-    lifetime: application
-    send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
+      - request-stats
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -183,11 +204,13 @@ ad_client:
 
   position:
     type: string
-    description: |
-      Supplied by the client if position within the placement is relevant (e.g. "1", "2", "top", "left-side").  May be null.
+    description: >
+      Supplied by the client if position within the placement is relevant
+      (e.g. "1", "2", "top", "left-side").  May be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -199,11 +222,14 @@ ad_client:
 
   form_factor:
     type: string
-    description: |
-      Form factor of the device displaying the ad (e.g. desktop, mobile). Should not be null.
+    description: >
+      Form factor of the device displaying the ad (e.g. desktop, mobile).
+      Should not be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
+      - request-stats
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -215,11 +241,12 @@ ad_client:
 
   os:
     type: string
-    description: |
+    description: >
       OS of the device displaying the ad.  May be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -227,47 +254,18 @@ ad_client:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
-    expires: never
-
-interaction:
-  kevel:
-    type: event
-    description: >
-      Captures specific Kevel fields.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/AE-355
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
-    notification_emails:
-      - gleonard@mozilla.com
-    expires: never
-    extra_keys:
-      flight_id:
-        description: >
-          Flight Id defined in Kevel metadata.
-        type: string
-  amp:
-    type: event
-    description: >
-      Captures specific AMP fields.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/AE-355
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
-    notification_emails:
-      - gleonard@mozilla.com
     expires: never
 
 technical_operations:
   user_agent:
     type: string
     description: >
-      User agent of the client.  Used for error investigation only, no analytics value.
+      User agent of the client.  Used for error investigation only, no
+      analytics value.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -280,10 +278,15 @@ technical_operations:
   served_timestamp:
     type: datetime
     description: >
-      Timestamp indicating when the ad was served by the Unified API to client.  This timestamp along with fetched_timestamp indicates the freshness of the ad.  If the ad is not cached on the server these two timestamps will differ by milliseconds. Should not be null.
+      Timestamp indicating when the ad was served by the Unified API to client.
+      This timestamp along with fetched_timestamp indicates the freshness of
+      the ad.  If the ad is not cached on the server these two timestamps will
+      differ by milliseconds. Should not be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
+      - request-stats
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -296,10 +299,14 @@ technical_operations:
   fetched_timestamp:
     type: datetime
     description: >
-      Timestamp indicating when the ad was fetched from the demand_source by the Unified API.  This timestamp along with served_timestamp indicates the freshness of the ad.  If the ad is not cached on the server these two timestamps will differ by milliseconds. Should not be null.
+      Timestamp indicating when the ad was fetched from the demand_source by
+      the Unified API.  This timestamp along with served_timestamp indicates
+      the freshness of the ad.  If the ad is not cached on the server these
+      two timestamps will differ by milliseconds. Should not be null.
     lifetime: application
     send_in_pings:
-      - events
+      - amp-interaction
+      - kevel-interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -307,4 +314,76 @@ technical_operations:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
+    expires: never
+
+  request_id:
+    type: string
+    description: >
+      ID generated server-side during an ad request to enable correlating ad
+      requests and reported interactions. This will help give insight into how
+      many ad requests are not used or how many are reused.
+    lifetime: application
+    send_in_pings:
+      - amp-interaction
+      - kevel-interaction
+      - request-stats
+    notification_emails:
+      - dmueller@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-577
+      - http://bugzilla.mozilla.org/TODO
+    data_reviews:
+      - http://bugzilla.mozilla.org/TODO
+    expires: never
+
+  count_requested:
+    type: quantity
+    unit: ads
+    description: >
+      Number of ads requested for a placement
+    lifetime: application
+    send_in_pings:
+      - request-stats
+    notification_emails:
+      - dmueller@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-577
+      - http://bugzilla.mozilla.org/TODO
+    data_reviews:
+      - http://bugzilla.mozilla.org/TODO
+    expires: never
+
+  count_returned:
+    type: quantity
+    unit: ads
+    description: >
+      Number of ads returned by an upstream provider for a placement
+    lifetime: application
+    send_in_pings:
+      - request-stats
+    notification_emails:
+      - dmueller@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-577
+      - http://bugzilla.mozilla.org/TODO
+    data_reviews:
+      - http://bugzilla.mozilla.org/TODO
+    expires: never
+
+  count_filtered:
+    type: quantity
+    unit: ads
+    description: >
+      Number of ads filtered by the server, such as by applying a blocklist
+      for the user, for a placement
+    lifetime: application
+    send_in_pings:
+      - request-stats
+    notification_emails:
+      - dmueller@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-577
+      - http://bugzilla.mozilla.org/TODO
+    data_reviews:
+      - http://bugzilla.mozilla.org/TODO
     expires: never

--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -315,9 +315,9 @@ technical_operations:
       - dmueller@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/AE-577
-      - http://bugzilla.mozilla.org/TODO
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158
     data_reviews:
-      - http://bugzilla.mozilla.org/TODO
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158
     expires: never
 
   count_requested:
@@ -332,9 +332,9 @@ technical_operations:
       - dmueller@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/AE-577
-      - http://bugzilla.mozilla.org/TODO
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158
     data_reviews:
-      - http://bugzilla.mozilla.org/TODO
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158
     expires: never
 
   count_returned:
@@ -349,9 +349,9 @@ technical_operations:
       - dmueller@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/AE-577
-      - http://bugzilla.mozilla.org/TODO
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158
     data_reviews:
-      - http://bugzilla.mozilla.org/TODO
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158
     expires: never
 
   count_filtered:
@@ -367,7 +367,7 @@ technical_operations:
       - dmueller@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/AE-577
-      - http://bugzilla.mozilla.org/TODO
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158
     data_reviews:
-      - http://bugzilla.mozilla.org/TODO
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158
     expires: never

--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -12,8 +12,7 @@ ad:
       null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -29,8 +28,7 @@ ad:
       Advertiser associated with the ad.  Should not be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -46,8 +44,7 @@ ad:
       Advertiser/partner provided identifier for a specific ad.  May be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -60,10 +57,11 @@ ad:
   flight_id:
     type: string
     description: >
-      Flight Id defined in Kevel metadata.  May be null.
+      Flight Id defined in Kevel metadata.  Will be null if interaction is
+      not from a Kevel supplied ad.
     lifetime: application
     send_in_pings:
-      - kevel-interaction
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -79,8 +77,7 @@ ad:
       The external service providing the ad.  Should not be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -97,8 +94,7 @@ ad:
       carousel, video).  Should not be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -115,8 +111,7 @@ ad:
       format can map to one product.  Should not be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -133,8 +128,7 @@ ad:
       Should not be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
       - request-stats
     notification_emails:
       - gleonard@mozilla.com
@@ -152,8 +146,7 @@ ad:
       be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
       - request-stats
     notification_emails:
       - gleonard@mozilla.com
@@ -172,8 +165,7 @@ ad_client:
       client.  Should not be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -190,8 +182,7 @@ ad_client:
       ad (e.g. newtab). Should not be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
       - request-stats
     notification_emails:
       - gleonard@mozilla.com
@@ -209,8 +200,7 @@ ad_client:
       (e.g. "1", "2", "top", "left-side").  May be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -227,8 +217,7 @@ ad_client:
       Should not be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
       - request-stats
     notification_emails:
       - gleonard@mozilla.com
@@ -245,8 +234,7 @@ ad_client:
       OS of the device displaying the ad.  May be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -264,8 +252,7 @@ technical_operations:
       analytics value.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -284,8 +271,7 @@ technical_operations:
       differ by milliseconds. Should not be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
       - request-stats
     notification_emails:
       - gleonard@mozilla.com
@@ -305,8 +291,7 @@ technical_operations:
       two timestamps will differ by milliseconds. Should not be null.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
     notification_emails:
       - gleonard@mozilla.com
     bugs:
@@ -324,8 +309,7 @@ technical_operations:
       many ad requests are not used or how many are reused.
     lifetime: application
     send_in_pings:
-      - amp-interaction
-      - kevel-interaction
+      - interaction
       - request-stats
     notification_emails:
       - dmueller@mozilla.com

--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -404,7 +404,7 @@ technical_operations:
     type: quantity
     unit: ads
     description: >
-      Number of ads filtered by the server, such as by applying a blocklist
+      Number of ads filtered by the server, from applying a blocklist
       for the user, for a placement
     lifetime: application
     send_in_pings:

--- a/telemetry/glean/pings.yaml
+++ b/telemetry/glean/pings.yaml
@@ -14,9 +14,9 @@ request-stats:
     - dmueller@mozilla.com
   bugs:
     - https://mozilla-hub.atlassian.net/browse/AE-577
-    - http://bugzilla.mozilla.org/TODO
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158
   data_reviews:
-    - http://bugzilla.mozilla.org/TODO
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158
 
 interaction:
   description: >
@@ -26,6 +26,6 @@ interaction:
     - dmueller@mozilla.com
   bugs:
     - https://mozilla-hub.atlassian.net/browse/AE-577
-    - http://bugzilla.mozilla.org/TODO
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158
   data_reviews:
-    - http://bugzilla.mozilla.org/TODO
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158

--- a/telemetry/glean/pings.yaml
+++ b/telemetry/glean/pings.yaml
@@ -18,21 +18,9 @@ request-stats:
   data_reviews:
     - http://bugzilla.mozilla.org/TODO
 
-kevel-interaction:
+interaction:
   description: >
-    Ad interaction with a Kevel supplied ad.
-  include_client_id: false
-  notification_emails:
-    - dmueller@mozilla.com
-  bugs:
-    - https://mozilla-hub.atlassian.net/browse/AE-577
-    - http://bugzilla.mozilla.org/TODO
-  data_reviews:
-    - http://bugzilla.mozilla.org/TODO
-
-amp-interaction:
-  description: >
-    Ad interaction with an AMP supplied ad.
+    Ad interaction with an ad.
   include_client_id: false
   notification_emails:
     - dmueller@mozilla.com

--- a/telemetry/glean/pings.yaml
+++ b/telemetry/glean/pings.yaml
@@ -1,0 +1,43 @@
+# Any copyright is dedicated to the Public Domain.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
+---
+# Schema
+$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
+
+request-stats:
+  description: >
+    Request stats for calculating performance, such as addressable inventory
+    or fill rates
+  include_client_id: false
+  notification_emails:
+    - dmueller@mozilla.com
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/AE-577
+    - http://bugzilla.mozilla.org/TODO
+  data_reviews:
+    - http://bugzilla.mozilla.org/TODO
+
+kevel-interaction:
+  description: >
+    Ad interaction with a Kevel supplied ad.
+  include_client_id: false
+  notification_emails:
+    - dmueller@mozilla.com
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/AE-577
+    - http://bugzilla.mozilla.org/TODO
+  data_reviews:
+    - http://bugzilla.mozilla.org/TODO
+
+amp-interaction:
+  description: >
+    Ad interaction with an AMP supplied ad.
+  include_client_id: false
+  notification_emails:
+    - dmueller@mozilla.com
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/AE-577
+    - http://bugzilla.mozilla.org/TODO
+  data_reviews:
+    - http://bugzilla.mozilla.org/TODO


### PR DESCRIPTION
### problem
We want to have a way to track request metrics in order to be able to calculate addressable inventory.
We also want to move away from using the events ping, so that we can easily have different fields in different pings; whereas the events ping + events extra is somewhat limiting in that regard

### solution
* convert the two event metrics we have defined to two custom pings
* adjust all the metrics tagged send_in_pings: events to also include those two new pings
* convert the event extra field for one of them to be a new metric only sendable in one ping
* define a new metric for request stats to help measure addressable inventory/fill rate
  * this metric has three counts (requested/returned/filtered) and then other fields that correlate to different inventory buckets 
* remove unused placement_id metric

removing the "send_in_pings: events" fields will come as a subsequent review since the process is multiple steps that happen on different cadences.
1. update these files for the new custom pings
2. probe scraper runs and picks up the new definitions, adding new ping tables
3. MARS is updated to log to custom pings and stop logging to the `events` ping
4. a subsequent review will remove the `events` related settings since they are no longer used by MARS

### testing
ran `glean_parser glinter telemetry/glean/metrics.yaml telemetry/glean/pings.yaml`


data review completed https://bugzilla.mozilla.org/show_bug.cgi?id=1928158