### PR TITLE
AE-860: adding creative_id and report_reason to interaction ping

### DIFF
--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -320,6 +320,40 @@ technical_operations:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1928158
     expires: never
 
+  creative_id:
+    type: string
+    description: >
+      Advertiser/partner provided identifier for assets used in a specific ad.  May be null.
+    lifetime: application
+    send_in_pings:
+      - interaction
+    notification_emails:
+      - gtan@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-860
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1968794
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1968794
+
+    expires: never
+
+  report_reason:
+    type: string
+    description: >
+      Reason selected by the user for reporting the ad
+    lifetime: application
+    send_in_pings:
+      - interaction
+    notification_emails:
+      - gtan@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-860
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1968794
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1968794
+
+    expires: never
+
   count_requested:
     type: quantity
     unit: ads


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/AE-860

adding 2 new fields -- creative_id and report_reason to existing interaction ping

data-review: https://bugzilla.mozilla.org/show_bug.cgi?id=1968794