### PR TITLE
Add line item id and creative id to the ad object

### DIFF
--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -54,6 +54,22 @@ ad:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
     expires: never
 
+  creative_id:
+    type: string
+    description: >
+      Advertiser/partner provided identifier for assets used in a specific ad.  May be null.
+    lifetime: application
+    send_in_pings:
+      - interaction
+    notification_emails:
+      - ads-eng@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-959
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1977255
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1977255
+    expires: never
+
   provider:
     type: string
     description: >
@@ -155,6 +171,23 @@ ad:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1900898
+    expires: never
+
+  line_item_id:
+    type: string
+    description: >
+      Advertiser/partner provided identifier for the line item used in a specific ad.
+      Will be null for a Kevel supplied ad, use flight_id instead.
+    lifetime: application
+    send_in_pings:
+      - interaction
+    notification_emails:
+      - ads-eng@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-959
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1977255
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1977255
     expires: never
 
 ad_client:


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/AE-959

Add 2 new fields to standardize reporting on ads.
* ad.line_item_id = this is the same as ad.flight_id, but with a general naming of what it actually is vs a vendor specific name (i.e. equativ uses insertion_id for line items)
* ad.creative_id = this is just moving the creative_id up from the technical_operations object. I think it makes more sense to report on it from the ad object than the tech ops object, though it is not currently used in data reporting and only in bad ad reports.

I also added the owner as ads-eng@mozilla.com. I think this makes sense to add a group if possible rather than individual owners. But I can update it if needed.

I am not sure if this required a data review, given we already collect the data, but I submitted one anyway:
https://bugzilla.mozilla.org/show_bug.cgi?id=1977255
