### PR TITLE
AE 1221: add feature flags

### DIFF
--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -627,3 +627,26 @@ provider_request:
     data_reviews:
       - https://github.com/mozilla-services/mars-telemetry/pull/7
     expires: never
+  
+  flags:
+    type: object
+    description:
+      The boolean state of all MARS experiment-backed feature flags
+      at the time this ping was recorded.
+    lifetime: application
+    send_in_pings:
+      - interaction
+      - request-stats    
+    notification_emails:
+      - ads-eng@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-1221
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2017878
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2017878
+    expires: never
+    structure:
+      type: object
+      properties:
+        sample_feature:
+          type: boolean

--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -630,7 +630,7 @@ provider_request:
   
   flags:
     type: object
-    description:
+    description: >
       The boolean state of all MARS experiment-backed feature flags
       at the time this ping was recorded.
     lifetime: application

--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -207,6 +207,29 @@ ad:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1984127
     expires: never
 
+  flags:
+    type: object
+    description: >
+      The boolean state of all MARS experiment-backed feature flags
+      at the time this ping was recorded.
+    lifetime: application
+    send_in_pings:
+      - interaction
+      - request-stats    
+    notification_emails:
+      - ads-eng@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/AE-1221
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2017878
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2017878
+    expires: never
+    structure:
+      type: object
+      properties:
+        sample_feature:
+          type: boolean
+
 ad_client:
   context_id:
     type: string
@@ -628,25 +651,3 @@ provider_request:
       - https://github.com/mozilla-services/mars-telemetry/pull/7
     expires: never
   
-  flags:
-    type: object
-    description: >
-      The boolean state of all MARS experiment-backed feature flags
-      at the time this ping was recorded.
-    lifetime: application
-    send_in_pings:
-      - interaction
-      - request-stats    
-    notification_emails:
-      - ads-eng@mozilla.com
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/AE-1221
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=2017878
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=2017878
-    expires: never
-    structure:
-      type: object
-      properties:
-        sample_feature:
-          type: boolean

--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -208,7 +208,7 @@ ad:
     expires: never
 
   flags:
-    type: object
+    type: labeled_boolean
     description: >
       The boolean state of all MARS experiment-backed feature flags
       at the time this ping was recorded.
@@ -224,11 +224,8 @@ ad:
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=2017878
     expires: never
-    structure:
-      type: object
-      properties:
-        sample_feature:
-          type: boolean
+    labels:
+      - sample_feature
 
 ad_client:
   context_id:


### PR DESCRIPTION
[AE-1221](https://mozilla-hub.atlassian.net/browse/AE-1221)
[Data Review Ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=2017878)

We are integrating with Nimbus, and want to start running experiments. To do so, requests and responses will start to include



```
"flags": {
	"flag_1": true,
	"flag_2": false,
}

```

Number of feature flags is undetermined. Each flag will have a boolean value. 