### PR TITLE
[AE-1319] Contextual Placement flag added to Glean for experiment

### DIFF
--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -260,6 +260,7 @@ ad:
     expires: never
     labels:
       - sample_feature
+      - contextual_placement
 
 ad_client:
   context_id:


### PR DESCRIPTION
In order to get metrics from nimbus experiments tied to control and treatment branches we need to use flags. This is to include boolean flag for contextual placement experiment in glean.

https://mozilla-hub.atlassian.net/browse/AE-1319
