### PR TITLE
feat(flags): add request_stats flag label

### DIFF
--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -261,6 +261,7 @@ ad:
     labels:
       - sample_feature
       - contextual_placement
+      - request_stats
 
 ad_client:
   context_id:


### PR DESCRIPTION
This PR adds a new flag label `request_stats`, which will be used to control a rollout of `RequestStats` emission in mars.