### PR TITLE
feat(adsBackend flags): Add `telemetry_comparison` flag

### DIFF
--- a/telemetry/glean/metrics.yaml
+++ b/telemetry/glean/metrics.yaml
@@ -262,6 +262,7 @@ ad:
       - sample_feature
       - contextual_placement
       - request_stats
+      - telemetry_comparison
 
 ad_client:
   context_id:


### PR DESCRIPTION
Adding a flag here to help with `newtab` vs `uapi` telemetry comparisons over time; largely to help keep a running tab of deviance that we can use as a rule of thumb in comparisons.